### PR TITLE
print message to console after do_deploy_api success

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: plumberDeploy
 Type: Package
 Title: Plumber Deployment
-Version: 0.1.3.9002
+Version: 0.1.3.9003
 Roxygen: list(markdown = TRUE)
 Authors@R: c(
   person("Bruno", "Tremblay", role = c("aut", "cre"), email = "cran@neoxone.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Development version
 
-Fix `do_deploy_api` using localPath `./`
+Fix `do_deploy_api` using localPath `./`.
+Print api url to console after successful `do_deploy_api`.
 
 # plumberDeploy 0.1.4
 

--- a/R/digital-ocean.R
+++ b/R/digital-ocean.R
@@ -388,12 +388,7 @@ do_deploy_api <- function(droplet, path, localPath, port, forward=FALSE,
   }
   service <- gsub("\\$PREFLIGHT\\$", preflight, service)
 
-  if (missing(docs)){
-    docs <- "FALSE"
-  } else {
-    docs <- "TRUE"
-  }
-  service <- gsub("\\$DOCS\\$", docs, service)
+  service <- gsub("\\$DOCS\\$", as.character(docs), service)
 
   servicefile <- tempfile()
   writeLines(service, servicefile)
@@ -436,6 +431,14 @@ do_deploy_api <- function(droplet, path, localPath, port, forward=FALSE,
   }
 
   analogsea::droplet_ssh(droplet, "systemctl reload nginx", ...)
+
+  public_ip <- analogsea:::droplet_ip_safe(droplet)
+  if (isTRUE(docs)) {
+    message("Navigate to ", public_ip, "/", path, "/__docs__/ to access api documentation.")
+  } else {
+    message("Api root url is ", public_ip, "/", path,". Any endpoints from api will be served relative to this root.")
+  }
+
 }
 
 #' Forward Root Requests to an API


### PR DESCRIPTION
Confusion about which url to use after executing `do_deploy_api`. Adding message to console.



PR task list:
- [x ] Update NEWS
- [ ] Add tests
- [ ] Update documentation with `devtools::document()`
